### PR TITLE
Fix actor attack/block/evade bonuses not applying to weapon and outfit dice

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -21,6 +21,9 @@ export class ActorPMTTRPG extends Actor {
 
     if (actorData.type === 'character' || actorData.type === 'npc') {
       this._prepareCharacterData(actorData);
+      for (const item of this.items) {
+        if (item.type === 'weapon' || item.type === 'outfit') item.prepareData();
+      }
     }
   }
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -89,8 +89,9 @@ export class ActorPMTTRPG extends Actor {
     data.attributes.hp.maxBase = hpMaxBase;
     data.attributes.hp.maxMisc = Number(data.attributes.hp.maxMisc) || 0;
     data.attributes.hp.max = hpMaxBase + data.attributes.hp.maxMisc;
-    if (!data.attributes.hp.value) data.attributes.hp.value = data.attributes.hp.max;
-    else {
+    if (data.attributes.hp.value === undefined || data.attributes.hp.value === null) {
+      data.attributes.hp.value = data.attributes.hp.max;
+    } else {
       data.attributes.hp.value = Math.clamp(Number(data.attributes.hp.value) || 0, 0, data.attributes.hp.max);
     }
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -111,10 +111,21 @@ export class ItemPMTTRPG extends Item {
         break;
       }
 
+      const tem = Number(actorData?.system?.abilities?.tem?.value ?? 0);
+      const ins = Number(actorData?.system?.abilities?.ins?.value ?? 0);
+      const eeMods = actorData?.system?.attributes?.easyEffectsMods;
+      const blockFromEffects = Number(eeMods?.blockPower ?? 0);
+      const evadeFromEffects = Number(eeMods?.evadePower ?? 0);
+      const blockTotal = blockPower + tem + blockFromEffects;
+      const evadeTotal = evadePower + ins + evadeFromEffects;
+      const formatDefensePower = (n) => (n ? (n > 0 ? `+${n}` : `${n}`) : '+0');
+
       data.blockDicePower = blockPower;
       data.evadeDicePower = evadePower;
-      data.blockDiceComputed = `1d${blockBaseSides}${blockPower ? (blockPower > 0 ? `+${blockPower}` : `${blockPower}`) : '+0'}`;
-      data.evadeDiceComputed = `1d${evadeBaseSides}${evadePower ? (evadePower > 0 ? `+${evadePower}` : `${evadePower}`) : '+0'}`;
+      data.dicePowerFromTemperance = tem;
+      data.dicePowerFromInsight = ins;
+      data.blockDiceComputed = `1d${blockBaseSides}${formatDefensePower(blockTotal)}`;
+      data.evadeDiceComputed = `1d${evadeBaseSides}${formatDefensePower(evadeTotal)}`;
 
       data.resistanceLevels = {
         fatal: { label: 'PMTTRPG.ResistanceFatal', multiplier: 2 },


### PR DESCRIPTION
## Summary
- Fold actor Insight/Temperance (and Always Active EasyEffects power) into outfit block/evade dice formulas.
- Re-prepare weapons and outfits after actor combat modifiers are computed so attack power (rank + effects) lands on weapon dice.
- Fixes #51 for both PCs and NPCs (this also affected PCs too).

## Related issue

Closes #51

## Testing

- [x] Tested locally
- [x] No console errors
- [x] Documentation updated (if applicable)

## Screenshots
(Note: While you mentioned that Outfit Evade should be +3, it should actually be +2, since +1 Insight and the outfit’s Swift bonus add up to +2.)
<img width="933" height="881" alt="image" src="https://github.com/user-attachments/assets/6c86246b-3f33-4c22-9f33-309dcb05f64e" />
