### PR TITLE
Added Clash Results to Effect's EasyScripts Scripts.

### DIFF
--- a/docs/EasyEffects/01_userguide.md
+++ b/docs/EasyEffects/01_userguide.md
@@ -593,12 +593,13 @@ increase damage by N*2;
 reduce damage by Protection after resistances;
 ```
 
-## Effect templates (`N`, `positive:`, `negative:`)
+## Effect templates (`N`, `positive:`, `negative:`, `RESULT`)
 
 Catalog **effect** items (Burn Resistance, etc.) can ship an EasyEffects template. Those templates may use:
 
 - bare `N` (also inside math like `N*2`) - equals the number of buyins for that effect on the equipment.
 - `positive:` / `negative:` - keep only the branch that matches the entry's Positive/Negative mode (sticky until the next polarity label or trigger)
+- `RESULT` inside a clash trigger - filled from the gear entry's Win / Lose / None dropdown (`procResult`). `Win` → `Win`, `Lose` → `Lose`. `None` drops that whole trigger block.
 
 Those tokens are **effect-template only**. They do not exist on equipment after sync.
 
@@ -612,7 +613,7 @@ reduce damage by 2;
 # <<< synced effects
 ```
 
-Adding, removing, or changing an effect's intensity or mode updates only that block. Put custom scripts **outside** the markers so they are not overwritten.
+Adding, removing, or changing an effect's intensity, mode, or clash result updates only that block. Put custom scripts **outside** the markers so they are not overwritten.
 
 If you edit *inside* the synced block, auto-update pauses and warns you. Use **Sync with current effects** twice to confirm a rebuild; text outside the markers is preserved.
 
@@ -625,6 +626,25 @@ reduce damage by N;
 negative:
 increase damage by N;
 ```
+
+Example template for a clash buy-in (Inflict Burn, etc.):
+
+```
+[Clash RESULT]
+positive:
+inflict N Burn;
+negative:
+gain N Burn;
+```
+
+With intensity `2` and clash result **Win**, sync stamps:
+
+```
+[Clash Win]
+inflict 2 Burn;
+```
+
+`[Clash RESULT With Evade]` and `[On Clash RESULT]` work the same way.
 
 Combat runs **only** the host's EasyEffects (not the catalog effect document).
 

--- a/docs/EasyEffects/04_cheatsheet.md
+++ b/docs/EasyEffects/04_cheatsheet.md
@@ -93,6 +93,18 @@ increase damage by N;
 
 Polarity stays active until the next polarity label or trigger.
 
+Clash Win / Lose from the gear dropdown uses `RESULT` in the trigger:
+
+```
+[Clash RESULT]
+positive:
+inflict N Burn;
+negative:
+gain N Burn;
+```
+
+Sync turns `RESULT` into `Win` or `Lose`. `None` skips that trigger block. Stance forms work too: `[Clash RESULT With Attack]`.
+
 Synced effects live between `# >>> synced effects` and `# <<< synced effects`. Keep custom scripts outside that block.
 
 ---

--- a/src/module/easy-effects/sync-from-effects.js
+++ b/src/module/easy-effects/sync-from-effects.js
@@ -8,32 +8,62 @@ const START_RE = /^#\s*>>>\s*synced effects\s*$/i;
 const END_RE = /^#\s*<<<\s*synced effects\s*$/i;
 
 /**
- * Bake an effect template for one polarity and intensity.
+
+ * @returns {{ trigger: string|null, usesResult: boolean }}
  */
-export function stampEffectEasyEffects(source, { mode = "positive", n = 1 } = {}) {
+function resolveClashResultTrigger(trigger, resultWord) {
+  if (!/\bRESULT\b/i.test(trigger)) return { trigger, usesResult: false };
+  if (!resultWord) return { trigger: null, usesResult: true };
+  return {
+    trigger: trigger.replace(/\bRESULT\b/gi, resultWord),
+    usesResult: true,
+  };
+}
+
+/**
+ * Bake an effect template for one polarity, intensity, and clash result.
+ * Template-only tokens: bare `N`, `positive:` / `negative:`, and `RESULT` in triggers.
+ */
+export function stampEffectEasyEffects(source, {
+  mode = "positive",
+  n = 1,
+  procResult = "none",
+} = {}) {
   const text = typeof source === "string" ? source : "";
   if (!text.trim()) return "";
 
   const intensity = Math.max(0, Math.round(Number(n) || 0));
   const wantMode = mode === "negative" ? "negative" : "positive";
+  const resultKey = String(procResult ?? "none").toLowerCase();
+  const resultWord = resultKey === "win" ? "Win" : resultKey === "lose" ? "Lose" : null;
   const lines = text.split(/\r?\n/);
   const out = [];
   let polarity = null; // null = unscoped (kept for any mode)
   let pendingTrigger = null;
+  let skipBlock = false;
 
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) {
-      if (out.length && out[out.length - 1] !== "") out.push("");
+      if (!skipBlock && out.length && out[out.length - 1] !== "") out.push("");
       continue;
     }
     if (trimmed.startsWith("#")) continue;
 
     if (/^\[.+\]$/.test(trimmed)) {
-      pendingTrigger = trimmed;
       polarity = null;
+      const resolved = resolveClashResultTrigger(trimmed, resultWord);
+      if (resolved.usesResult && !resolved.trigger) {
+        pendingTrigger = null;
+        skipBlock = true;
+        continue;
+      }
+      pendingTrigger = resolved.trigger;
+      skipBlock = false;
       continue;
     }
+
+    if (skipBlock) continue;
 
     const polOnly = trimmed.match(/^(positive|negative)\s*:$/i);
     if (polOnly) {
@@ -182,6 +212,7 @@ export async function buildEasyEffectsFromEffects(effects = []) {
     const stamped = stampEffectEasyEffects(template, {
       mode: entry?.mode === "negative" ? "negative" : "positive",
       n: getEffectStack(entry),
+      procResult: entry?.procResult ?? "none",
     });
     if (!stamped.trim()) continue;
 


### PR DESCRIPTION
## Summary

Just a super quick implementation of adding `On Clash Win/Lose` to Effects EE Templates.. use RESULT in a Clash Trigger. Can also do `[On Clash RESULT with Block]`.
```
[On Clash RESULT]
positive:
inflict N Ruin;
negative:
gain N Ruin;
```


## Testing

- [x] Tested locally
- [x] No console errors
- [x] Documentation updated (if applicable)

## Screenshots
<img width="538" height="562" alt="image" src="https://github.com/user-attachments/assets/5cefd0c6-b27b-4c32-aa28-8e1ef64e13a1" />
<img width="661" height="824" alt="image" src="https://github.com/user-attachments/assets/020a222b-cbcc-499e-8846-300b6022c40a" />
<img width="665" height="477" alt="image" src="https://github.com/user-attachments/assets/3848b1fd-e09c-41ff-8bde-ac51ac610bb0" />