### PR TITLE
Update combat-turn-order.css

### DIFF
--- a/src/styles/lib/combat-turn-order.css
+++ b/src/styles/lib/combat-turn-order.css
@@ -45,6 +45,11 @@
     box-sizing: border-box;
 }
 
+/* additional styling when player's turn is active */
+.ct .character.current-turn {
+    box-shadow: inset 30px 0px 20px -20px var(--ct-gold);
+}
+
 /* ── Main row ── */
 .ct .main-part {
     display: flex;


### PR DESCRIPTION
Adds a small gradient to the left side of the combat tracker for the active character.

## Summary

Changes combat-turn-order.css to add a .current-turn styling, which clarifies the current character in combat.

## Related issue

Closes #102 

## Screenshots

<img width="305" height="82" alt="image" src="https://github.com/user-attachments/assets/734f4208-238e-4207-bb44-f088c480a7a7" />