### PR TITLE
EE fixes and other changes.

### DIFF
--- a/src/module/actor/actor-npc-sheet.js
+++ b/src/module/actor/actor-npc-sheet.js
@@ -82,11 +82,8 @@ export class PMTTRPGActorNpcSheet extends PMTTRPGCharacterSheet {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
 
-    // NPC loadout is always active so we don't need equip filtering.
     context.loadoutWeapons = (context.allWeapons ?? []).slice();
     context.loadoutOutfits = (context.outfits ?? []).slice();
-    context.equippedWeapons = context.loadoutWeapons;
-    context.equippedOutfits = context.loadoutOutfits;
 
     const brief = context.system?.details?.gmBrief ?? {};
     context.gmBrief = {
@@ -106,9 +103,8 @@ export class PMTTRPGActorNpcSheet extends PMTTRPGCharacterSheet {
   async _prepareCharacterItems(sheetData) {
     await super._prepareCharacterItems(sheetData);
 
-    // Skills resolve against the first loadout weapon/outfit (no equip flag).
-    const weapon = this.actor.items.find(i => i.type === "weapon");
-    const outfit = this.actor.items.find(i => i.type === "outfit");
+    const weapon = this.actor.items.find(i => i.type === "weapon" && i.system?.equipped);
+    const outfit = this.actor.items.find(i => i.type === "outfit" && i.system?.equipped);
     for (const s of sheetData.skills ?? []) {
       s.equippedWeaponDamageType = weapon?.system?.damageType || null;
       s.equippedWeaponOffensiveDiceComputed = weapon?.system?.offensiveDiceComputed || null;
@@ -132,8 +128,7 @@ export class PMTTRPGActorNpcSheet extends PMTTRPGCharacterSheet {
     delete data.name;
 
     const system = { ...data };
-    //  NPC weapons/outfits/skills/augments are always active so we mark loadout items equipped for shared roll/effect code paths.
-    if (["weapon", "outfit", "skill", "augment"].includes(type)) {
+    if (["weapon", "outfit"].includes(type)) {
       system.equipped = true;
     }
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1,5 +1,5 @@
 import { PMTTRPGUtility } from '../utility.js';
-import { getActionEconomyFromRank, getRankFromLevel, TACTICAL_SQUARES_BASE } from './progression.js';
+import { getActionEconomyFromRank, getRankFromLevel, TACTICAL_SQUARES_BASE, squareTurnCap } from './progression.js';
 import { actorHistorySquareCost, actorSquaresExhausted } from '../combat/movement.js';
 const { renderTemplate } = foundry.applications.handlebars;
 import { applyAlwaysActiveModifiers, runOnTakingDamage } from '../easy-effects/registry.js';
@@ -21,6 +21,11 @@ import {
 
 const STATUS_STACK_HOOK_MAX_DEPTH = 8;
 const _statusStackHookDepth = new WeakMap();
+
+function sourceSystemNumber(actorData, path) {
+  const n = Number(foundry.utils.getProperty(actorData._source ?? {}, `system.${path}`));
+  return Number.isFinite(n) ? n : 0;
+}
 
 function statusMutationOptions(options = {}, delta = 0) {
   const silent = !!options.silent;
@@ -142,7 +147,7 @@ export class ActorPMTTRPG extends Actor {
     const hpMaxBase = 64 + (fort * 8) + (rank * 32);
     if (!data.attributes.hp) data.attributes.hp = {};
     data.attributes.hp.maxBase = hpMaxBase;
-    data.attributes.hp.maxMisc = Number(data.attributes.hp.maxMisc) || 0;
+    data.attributes.hp.maxMisc = sourceSystemNumber(actorData, "attributes.hp.maxMisc");
     data.attributes.hp.max = hpMaxBase + data.attributes.hp.maxMisc;
     if (data.attributes.hp.value === undefined || data.attributes.hp.value === null) {
       data.attributes.hp.value = data.attributes.hp.max;
@@ -154,7 +159,7 @@ export class ActorPMTTRPG extends Actor {
     const stMaxBase = 20 + (cha * 4) + (rank * 4);
     data.attributes.st = data.attributes.st || {};
     data.attributes.st.maxBase = stMaxBase;
-    data.attributes.st.maxMisc = Number(data.attributes.st.maxMisc) || 0;
+    data.attributes.st.maxMisc = sourceSystemNumber(actorData, "attributes.st.maxMisc");
     data.attributes.st.max = stMaxBase + data.attributes.st.maxMisc;
     if (data.attributes.st.value === undefined || data.attributes.st.value === null) {
       data.attributes.st.value = data.attributes.st.max;
@@ -177,7 +182,7 @@ export class ActorPMTTRPG extends Actor {
 
     data.attributes.sp = data.attributes.sp || {};
     data.attributes.sp.maxBase = spMaxBase;
-    data.attributes.sp.maxMisc = Number(data.attributes.sp.maxMisc) || 0;
+    data.attributes.sp.maxMisc = sourceSystemNumber(actorData, "attributes.sp.maxMisc");
     data.attributes.sp.max = spMaxBase + data.attributes.sp.maxMisc;
     if (data.attributes.sp.value === undefined || data.attributes.sp.value === null) {
       data.attributes.sp.value = data.attributes.sp.max;
@@ -189,7 +194,7 @@ export class ActorPMTTRPG extends Actor {
     const lightMaxBase = 3 + rank;
     data.attributes.light = data.attributes.light || {};
     data.attributes.light.maxBase = lightMaxBase;
-    data.attributes.light.maxMisc = Number(data.attributes.light.maxMisc) || 0;
+    data.attributes.light.maxMisc = sourceSystemNumber(actorData, "attributes.light.maxMisc");
     data.attributes.light.max = lightMaxBase + data.attributes.light.maxMisc;
     if (data.attributes.light.value === undefined || data.attributes.light.value === null) {
       data.attributes.light.value = data.attributes.light.max;
@@ -207,7 +212,7 @@ export class ActorPMTTRPG extends Actor {
       data.attributes[key] = pool;
       pool.min = 0;
       pool.maxBase = maxBase;
-      pool.maxMisc = Number(pool.maxMisc) || 0;
+      pool.maxMisc = sourceSystemNumber(actorData, `attributes.${key}.maxMisc`);
       pool.max = pool.maxBase + pool.maxMisc;
       if (pool.value === undefined || pool.value === null) {
         pool.value = pool.max;
@@ -220,7 +225,7 @@ export class ActorPMTTRPG extends Actor {
     data.attributes.squares = squares;
     squares.min = 0;
     squares.maxBase = TACTICAL_SQUARES_BASE;
-    squares.maxMisc = Number(squares.maxMisc) || 0;
+    squares.maxMisc = sourceSystemNumber(actorData, "attributes.squares.maxMisc");
     squares.max = Math.max(0, squares.maxBase + squares.maxMisc);
     if (squares.value === undefined || squares.value === null) {
       squares.value = squares.max;
@@ -333,7 +338,7 @@ export class ActorPMTTRPG extends Actor {
       squaresPool.exhausted = actorSquaresExhausted(this);
       squaresPool.remaining = squaresPool.exhausted
         ? 0
-        : Math.max(0, squaresPool.value - usedSquares);
+        : Math.max(0, squareTurnCap(squaresPool) - usedSquares);
     }
 
     applyInventorySlotUsage(data.attributes, actorData.items);

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -228,15 +228,14 @@ export class ActorPMTTRPG extends Actor {
       squares.value = Math.max(0, Number(squares.value) || 0);
     }
 
-    // Equipped outfit bonuses. NPCs always use their loadout outfits.
+    // Equipped outfit bonuses.
     let outfitBlockBonus = 0;
     let outfitEvadeBonus = 0;
     let outfitLightBonus = 0;
     let outfitEpBonus = 0;
-    const isNpc = actorData.type === 'npc';
     for (let item of actorData.items || []) {
       if (item.type != 'outfit') continue;
-      if (!isNpc && !item.system?.equipped) continue;
+      if (!item.system?.equipped) continue;
       outfitBlockBonus += Number(item.system?.blockDicePower ?? 0);
       outfitEvadeBonus += Number(item.system?.evadeDicePower ?? 0);
       outfitLightBonus += Number(item.system?.bonusLight ?? 0);

--- a/src/module/actor/progression.js
+++ b/src/module/actor/progression.js
@@ -42,3 +42,11 @@ export const RANK_UP_LEVELS = [3, 6, 9, 12, 15];
 export const XP_PER_LEVEL = 8;
 
 export const TACTICAL_SQUARES_BASE = 6;
+
+export function squareTurnCap(squares) {
+  if (!squares) return 0;
+  const max = Math.max(0, Number(squares.max) || 0);
+  const value = Math.max(0, Number(squares.value) || 0);
+  const maxBase = Math.max(0, Number(squares.maxBase) || TACTICAL_SQUARES_BASE);
+  return max + Math.max(0, value - Math.max(max, maxBase));
+}

--- a/src/module/canvas/token-ruler.js
+++ b/src/module/canvas/token-ruler.js
@@ -1,3 +1,5 @@
+import { squareTurnCap } from "../actor/progression.js";
+
 const OVER_COLOR = 0xE23D28;
 
 function isCurrentTurn(token) {
@@ -17,26 +19,24 @@ function isCurrentTurn(token) {
 
 function accruedCost(waypoint) {
   const spaces = Number(waypoint?.measurement?.spaces);
-  if (Number.isFinite(spaces) && spaces >= 0) return spaces;
+  if (Number.isFinite(spaces) && spaces >= 0) return Math.max(0, Math.round(spaces));
   const distance = Number(waypoint?.measurement?.distance);
   const cell = Number(canvas?.grid?.distance) || 1;
-  if (Number.isFinite(distance) && distance >= 0 && cell > 0) return distance / cell;
+  if (Number.isFinite(distance) && distance >= 0 && cell > 0) {
+    return Math.max(0, Math.round(distance / cell));
+  }
   const measured = Number(waypoint?.measurement?.cost);
-  if (Number.isFinite(measured) && measured >= 0) return measured;
+  if (Number.isFinite(measured) && measured >= 0) return Math.max(0, Math.round(measured));
   const cost = Number(waypoint?.cost);
-  if (Number.isFinite(cost) && cost >= 0) return cost;
+  if (Number.isFinite(cost) && cost >= 0) return Math.max(0, Math.round(cost));
   return 0;
 }
 
 function squareBudget(actor) {
   const squares = actor?.system?.attributes?.squares;
-  if (squares?.exhausted) {
-    const used = Number(squares.used);
-    return Math.max(0, Number.isFinite(used) ? used : 0);
-  }
-  const source = Number(actor?._source?.system?.attributes?.squares?.value);
-  if (Number.isFinite(source)) return Math.max(0, source);
-  return Math.max(0, Number(squares?.value) || 0);
+  if (!squares) return 0;
+  if (squares.exhausted) return Math.max(0, Number(squares.used) || 0);
+  return squareTurnCap(squares);
 }
 
 export function registerTokenRuler() {

--- a/src/module/combat/clashing.js
+++ b/src/module/combat/clashing.js
@@ -260,6 +260,8 @@ async function _executeClash(state, retaliatorActor, choice) {
   // Rebuild clash context so EasyEffects On Clash can add bonuses before the roll.
   const clashCtx = createClashContext();
   clashCtx.isRecycledEvade = isRecycled;
+  clashCtx.attackerSkill = attackerSkill;
+  clashCtx.defenderSkill = defenderSkill;
   const defenderItem = choice.item ?? null;
   const clashPayloadBase = {
     attacker:     attackerActor,

--- a/src/module/combat/clashing.js
+++ b/src/module/combat/clashing.js
@@ -446,8 +446,8 @@ async function _executeClash(state, retaliatorActor, choice) {
   if (isRecycled && result === CLASH_RESULTS.ATTACK_WIN) {
     await clearRecycledEvade(retaliatorActor);
   } else if (result === CLASH_RESULTS.DEFENSE_WIN && _isEvadeLike(choice)) {
-    if (isRecycled) await bumpRecycledEvade(retaliatorActor);
-    else await grantRecycledEvade(retaliatorActor);
+    if (isRecycled) await bumpRecycledEvade(retaliatorActor, choice.item);
+    else await grantRecycledEvade(retaliatorActor, choice.item);
   }
 
   if (result === CLASH_RESULTS.ATTACK_WIN) {

--- a/src/module/combat/clashing.js
+++ b/src/module/combat/clashing.js
@@ -328,6 +328,11 @@ async function _executeClash(state, retaliatorActor, choice) {
 
   let { result, margin } = resolveClash(attackTotal, defenseResult.total);
 
+  if (choice.type === RETALIATION_TYPES.ONESIDED) {
+    result = CLASH_RESULTS.ATTACK_WIN;
+    margin = Math.max(0, attackTotal);
+  }
+
   while (result === CLASH_RESULTS.TIE && choice.type !== RETALIATION_TYPES.ONESIDED) {
     const [attackReroll, defenseReroll] = await Promise.all([
       rollAttack(attackerActor, attackerItem, clashCtx.bonuses.attacker),

--- a/src/module/combat/movement.js
+++ b/src/module/combat/movement.js
@@ -161,7 +161,22 @@ async function emitMovedIfNeeded(tokenDoc, movement, operation, user) {
   }
 }
 
+function registerCombatDocument() {
+  const Base = CONFIG.Combat.documentClass;
+
+  class CombatPMTTRPG extends Base {
+    /** @override */
+    async _clearMovementHistoryOnStartTurn(combatant, _context) {
+      if (!combatant) return;
+      return combatant.clearMovementHistory();
+    }
+  }
+
+  CONFIG.Combat.documentClass = CombatPMTTRPG;
+}
+
 export function registerCombatMovement() {
+  registerCombatDocument();
   registerTokenRuler();
 
   Hooks.on("moveToken", (tokenDoc, movement, operation, user) => {

--- a/src/module/combat/recycled-evade.js
+++ b/src/module/combat/recycled-evade.js
@@ -1,7 +1,11 @@
 const FLAG_SCOPE = "projectmoonttrpg";
 const FLAG_KEY = "recycledEvade";
 const DEFAULT_PENALTY = 2;
-const PENALTY_STEP = 2;
+
+/** if the outfit has the swift property, the penalty is 1 instead of 2 */
+function recycledEvadeStep(outfit) {
+  return outfit?.system?.outfitProperty === "swift" ? 1 : DEFAULT_PENALTY;
+}
 
 /**
  * @param {Actor|null|undefined} actor
@@ -15,21 +19,21 @@ export function getRecycledEvade(actor) {
   return { active: true, penalty };
 }
 
-/** @param {Actor} actor */
-export async function grantRecycledEvade(actor) {
+/** @param {Actor} actor @param {Item|null} [outfit] */
+export async function grantRecycledEvade(actor, outfit = null) {
   if (!actor) return;
   if (getRecycledEvade(actor)) return;
-  await actor.setFlag(FLAG_SCOPE, FLAG_KEY, { active: true, penalty: DEFAULT_PENALTY });
+  await actor.setFlag(FLAG_SCOPE, FLAG_KEY, { active: true, penalty: recycledEvadeStep(outfit) });
 }
 
-/** @param {Actor} actor */
-export async function bumpRecycledEvade(actor) {
+/** @param {Actor} actor @param {Item|null} [outfit] */
+export async function bumpRecycledEvade(actor, outfit = null) {
   if (!actor) return;
   const current = getRecycledEvade(actor);
   if (!current) return;
   await actor.setFlag(FLAG_SCOPE, FLAG_KEY, {
     active: true,
-    penalty: current.penalty + PENALTY_STEP,
+    penalty: current.penalty + recycledEvadeStep(outfit),
   });
 }
 

--- a/src/module/damage-application.js
+++ b/src/module/damage-application.js
@@ -87,16 +87,13 @@ export function damageTypeLabel(damageType) {
 
 export function getActorWeaponDamageType(actor) {
   if (!actor) return null;
-  const weapon = actor.type === "npc"
-    ? actor.items.find((item) => item.type === "weapon")
-    : actor.items.find((item) => item.type === "weapon" && item.system?.equipped);
+  const weapon = actor.items.find((item) => item.type === "weapon" && item.system?.equipped);
   const damageType = weapon?.system?.damageType;
   return DAMAGE_TYPES.includes(damageType) ? damageType : null;
 }
 
 export function getEquippedOutfit(actor) {
   if (!actor) return null;
-  if (actor.type === "npc") return actor.items.find((i) => i.type === "outfit") ?? null;
   return actor.items.find((i) => i.type === "outfit" && i.system?.equipped) ?? null;
 }
 

--- a/src/module/easy-effects/interpreter.js
+++ b/src/module/easy-effects/interpreter.js
@@ -456,10 +456,53 @@ function resolvePath(segments, context) {
     if (shorthand !== null) return shorthand;
   }
 
-  if (sub[0] === "stat"  && sub[1]) return actor.system.abilities?.[sub[1]]?.value ?? 0;
-  if (sub[0] === "attr"  && sub[1]) return actor.system.attributes?.[sub[1]]?.value ?? 0;
+  if (sub[0] === "stat" && sub[1]) {
+    if (sub.length === 2) return actor.system.abilities?.[sub[1]]?.value ?? 0;
+    const walkedStat = walkObjectPath(actor.system?.abilities?.[sub[1]], sub.slice(2));
+    if (walkedStat !== undefined) return coerceActorPathValue(walkedStat);
+  }
+
+  if (sub[0] === "attr" && sub[1]) {
+    const bag = actor.system?.attributes?.[sub[1]];
+    if (sub.length === 2) return Number(bag?.value) || 0;
+    const walkedAttr = walkObjectPath(bag, sub.slice(2));
+    if (walkedAttr !== undefined) return coerceActorPathValue(walkedAttr);
+  }
+
+  const walked = walkActorPath(actor, sub);
+  if (walked !== undefined) return coerceActorPathValue(walked);
 
   console.warn(`[EasyEffects] Unknown path: '${segments.join(".")}'`);
+  return 0;
+}
+
+function walkObjectPath(root, segments) {
+  if (root == null || !segments?.length) return undefined;
+  let cur = root;
+  for (const seg of segments) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = cur[seg];
+  }
+  if (typeof cur === "function") return undefined;
+  return cur;
+}
+
+function walkActorPath(actor, segments) {
+  const fromActor = walkObjectPath(actor, segments);
+  if (fromActor !== undefined) return fromActor;
+  const fromSystem = walkObjectPath(actor.system, segments);
+  if (fromSystem !== undefined) return fromSystem;
+  return walkObjectPath(actor.system?.attributes, segments);
+}
+
+function coerceActorPathValue(value) {
+  if (value == null) return 0;
+  if (typeof value === "function") return 0;
+  if (typeof value === "number" || typeof value === "boolean") return Number(value);
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value.value !== undefined && typeof value.value !== "object") {
+    return coerceActorPathValue(value.value);
+  }
   return 0;
 }
 
@@ -1357,7 +1400,6 @@ export function executeAlwaysActive(ast, prepareContext) {
         if (stmt.condition && !evaluateConditionSync(stmt.condition, context)) continue;
 
         for (const action of stmt.actions) {
-          const amount = Math.max(0, Math.round(resolveAmountSync(action.amount, context)));
           let rawAmount = resolveAmountSync(action.amount, context);
           if (action.per) rawAmount *= resolveAmountSync(action.per, context);
           const amount = Math.max(0, Math.round(rawAmount));

--- a/src/module/easy-effects/interpreter.js
+++ b/src/module/easy-effects/interpreter.js
@@ -924,6 +924,8 @@ const ACTION_HANDLERS = {
         attacker: context.attacker ?? context.target ?? null,
         clash: context.clash ?? null,
         sourceItem: context.item ?? null,
+        attackerSkill: context.attackerSkill ?? context.clash?.attackerSkill ?? null,
+        defenderSkill: context.defenderSkill ?? context.clash?.defenderSkill ?? null,
         depth: Number(context._burstDepth) || 0,
       });
     }
@@ -958,6 +960,8 @@ const ACTION_HANDLERS = {
         target: context.target ?? null,
         clash: context.clash ?? null,
         sourceItem: context.item ?? null,
+        attackerSkill: context.attackerSkill ?? context.clash?.attackerSkill ?? null,
+        defenderSkill: context.defenderSkill ?? context.clash?.defenderSkill ?? null,
         binds,
         depth: Number(context._procDepth) || 0,
       });

--- a/src/module/easy-effects/interpreter.js
+++ b/src/module/easy-effects/interpreter.js
@@ -1358,6 +1358,9 @@ export function executeAlwaysActive(ast, prepareContext) {
 
         for (const action of stmt.actions) {
           const amount = Math.max(0, Math.round(resolveAmountSync(action.amount, context)));
+          let rawAmount = resolveAmountSync(action.amount, context);
+          if (action.per) rawAmount *= resolveAmountSync(action.per, context);
+          const amount = Math.max(0, Math.round(rawAmount));
 
           switch (action.verb) {
             case "power up": {

--- a/src/module/easy-effects/nouns.js
+++ b/src/module/easy-effects/nouns.js
@@ -109,6 +109,8 @@ export const NOUNS = {
     path: "system.attributes.squares.value",
     readPath: "system.attributes.squares.remaining",
     alwaysActive: false,
+    alwaysActivePath: "system.attributes.squares.maxMisc",
+    alwaysActiveModKey: "squaresMaxMisc",
     ops: ["gain", "lose", "set"],
     pathShorthand: true,
     aliases: ["square", "squares", "sqr", "sqrs"],
@@ -219,7 +221,7 @@ export function isResourceNoun(name) {
 
 export function isAlwaysActiveResource(name) {
   const hit = lookupNoun(name);
-  return !!hit && hit.def.kind === "resource" && !!hit.def.alwaysActive;
+  return !!hit && hit.def.kind === "resource" && !!(hit.def.alwaysActive || hit.def.alwaysActivePath);
 }
 
 export function isRuntimeResource(name) {
@@ -365,8 +367,9 @@ export function emptyAlwaysActiveMods() {
     resistanceOverrideSources: {},
   };
   for (const def of Object.values(NOUNS)) {
-    if (def.kind !== "resource" || !def.alwaysActive) continue;
-    const key = def.modKey ?? null;
+    if (def.kind !== "resource") continue;
+    if (!def.alwaysActive && !def.alwaysActivePath) continue;
+    const key = def.alwaysActiveModKey ?? def.modKey ?? null;
     if (key && mods[key] === undefined) mods[key] = 0;
   }
   return mods;
@@ -375,8 +378,8 @@ export function emptyAlwaysActiveMods() {
 export function applyResourceMod(mods, nounId, signedAmount) {
   const hit = lookupNoun(nounId);
   if (!hit || hit.def.kind !== "resource") return false;
-  if (!hit.def.alwaysActive) return false;
-  const key = hit.def.modKey ?? hit.id;
+  if (!hit.def.alwaysActive && !hit.def.alwaysActivePath) return false;
+  const key = hit.def.alwaysActiveModKey ?? hit.def.modKey ?? hit.id;
   mods[key] = (mods[key] ?? 0) + signedAmount;
   return true;
 }
@@ -393,10 +396,12 @@ export function applyResourceOverride(mods, nounId, value) {
 
 export function applyResourceModsToSystem(systemData, eeMods) {
   for (const [id, def] of Object.entries(NOUNS)) {
-    if (def.kind !== "resource" || !def.alwaysActive || !def.path) continue;
-    const amount = eeMods[def.modKey ?? id] ?? 0;
+    if (def.kind !== "resource") continue;
+    const path = def.alwaysActivePath || (def.alwaysActive ? def.path : null);
+    if (!path) continue;
+    const amount = eeMods[def.alwaysActiveModKey ?? def.modKey ?? id] ?? 0;
     if (!amount) continue;
-    const rel = def.path.replace(/^system\./, "");
+    const rel = path.replace(/^system\./, "");
     const parts = rel.split(".");
     let cur = systemData;
     for (let i = 0; i < parts.length - 1; i++) {

--- a/src/module/easy-effects/parser.js
+++ b/src/module/easy-effects/parser.js
@@ -1647,7 +1647,7 @@ class Parser {
         throw new ParseError(`'${verbTok.value}' is not allowed on resource '${resourceHit.id}'`, verbTok);
       this.advance();
 
-      let target = this._parseOptionalOnOrToTarget() ?? "self";
+      const tail = this._parseStatusOrResourceTail({ allowTiming: false });
 
       const verb = verbTok.value === "lose" ? "remove" : "add";
       return {
@@ -1656,8 +1656,8 @@ class Parser {
         noun: "resource",
         argument: resourceHit.id,
         amount,
-        per: null,
-        target,
+        per: tail.per,
+        target: tail.target ?? "self",
       };
     }
 
@@ -1665,10 +1665,7 @@ class Parser {
 
     // inflict defaults to "target"; gain/lose default to "self"
     const defaultTarget = verbTok.value === "inflict" ? "target" : "self";
-    let timing = this._parseOptionalTiming();
-    let target = this._parseOptionalOnOrToTarget() ?? null;
-    if (!timing) timing = this._parseOptionalTiming();
-    if (!target) target = defaultTarget;
+    const tail = this._parseStatusOrResourceTail();
 
     // Resolve verb → add/remove, baking in the default target
     const verb = verbTok.value === "lose" ? "remove" : "add";
@@ -1679,10 +1676,34 @@ class Parser {
       noun: "status",
       argument: statusName,
       amount,
-      per: null,
-      target,
-      timing,
+      per: tail.per,
+      target: tail.target ?? defaultTarget,
+      timing: tail.timing,
     };
+  }
+
+  _parseStatusOrResourceTail({ allowTiming = true } = {}) {
+    let per = null;
+    let timing = null;
+    let target = null;
+
+    for (;;) {
+      if (!per) {
+        const nextPer = this._parseOptionalPerAmount();
+        if (nextPer) { per = nextPer; continue; }
+      }
+      if (allowTiming && !timing) {
+        const nextTiming = this._parseOptionalTiming();
+        if (nextTiming) { timing = nextTiming; continue; }
+      }
+      if (!target) {
+        const nextTarget = this._parseOptionalOnOrToTarget();
+        if (nextTarget) { target = nextTarget; continue; }
+      }
+      break;
+    }
+
+    return { per, timing, target };
   }
 
   /** Timing may appear before or after the target. */

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -111,6 +111,15 @@ function collectSideClashItems(actor, usedItem, appliedTool, declaredSkill) {
   return out;
 }
 
+function usedStatBlockItems(usedItem, appliedTool, declaredSkill) {
+  const out = [];
+  const seen = new Set();
+  addUniqueItem(out, seen, usedItem);
+  addUniqueItem(out, seen, appliedTool);
+  addUniqueItem(out, seen, declaredSkill);
+  return out;
+}
+
 function clashUsedStatBlocks({
   attackerItem,
   defenderItem,
@@ -410,6 +419,13 @@ const TRIGGER_HOOKS = [
       ally:   null,
       clash:  null,
     }),
+  },
+  {
+    hook: "pmttrpg.clashStarted",
+    triggerName: "On Use",
+    getItems: clashUsedStatBlocks,
+    buildContext: buildClashStartedContext,
+    getActorContexts: () => [],
   },
 
   // ── [On Action] ─────────────────────────────────────────────────────────────

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -177,6 +177,10 @@ function buildClashStartedActorContext(payload, self) {
   };
 }
 
+function isOneSidedRetaliation(payload) {
+  return String(payload?.retaliationType ?? "").toLowerCase() === "onesided";
+}
+
 function clashWinItems({
   winner,
   attacker,
@@ -204,7 +208,9 @@ function clashLoseItems({
   defenderAppliedTool,
   attackerSkill,
   defenderSkill,
+  retaliationType,
 } = {}) {
+  if (isOneSidedRetaliation({ retaliationType })) return [];
   const attackerWon = winner === attacker;
   return attackerWon
     ? collectSideClashItems(defender, defenderItem, defenderAppliedTool, defenderSkill)
@@ -225,6 +231,7 @@ function buildClashWinContext(payload = {}) {
 }
 
 function buildClashLoseContext(payload = {}) {
+  if (isOneSidedRetaliation(payload)) return null;
   const { winner, loser, attacker, defender, attackerRoll, defenderRoll, clash } = payload;
   return {
     self: loser,

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -341,10 +341,11 @@ const TRIGGER_HOOKS = [
       if (attacker) out.push(...uniqueStatusItems(attacker.items));
       return out;
     },
-    buildContext: ({ attacker, defender, clash }) => ({
+    buildContext: ({ attacker, defender, clash, attackerSkill }) => ({
       self:   attacker,
       target: defender,
       attacker: attacker ?? null,
+      attackerSkill: attackerSkill ?? clash?.attackerSkill ?? null,
       ally:   null,
       clash:  clash ?? createClashContext(),
     }),
@@ -355,7 +356,7 @@ const TRIGGER_HOOKS = [
     hook: "pmttrpg.attackConnected",
     triggerName: "On Being Hit",
     getItems: ({ defender }) => defender ? uniqueStatusItems(defender.items) : [],
-    buildContext: ({ attacker, defender, clash }) => {
+    buildContext: ({ attacker, defender, clash, attackerSkill }) => {
       if (!defender) return null;
       return {
         self: defender,
@@ -798,6 +799,49 @@ export async function emitClashResolved(payload = {}) {
 
 const BURST_NEST_MAX_DEPTH = 8;
 
+function usedSkillsFromContext({
+  sourceItem = null,
+  attackerSkill = null,
+  defenderSkill = null,
+  clash = null,
+} = {}) {
+  return [sourceItem, attackerSkill, defenderSkill, clash?.attackerSkill, clash?.defenderSkill]
+    .filter((item) => item?.type === "skill");
+}
+
+function collectUsedSkills(owner, usedSkills) {
+  if (!owner) return [];
+  const out = [];
+  const seen = new Set();
+  for (const item of usedSkills ?? []) {
+    if (item?.type !== "skill" || !item.id || seen.has(item.id)) continue;
+    const onOwner = item.actor?.id === owner.id || owner.items?.get?.(item.id);
+    if (!onOwner) continue;
+    seen.add(item.id);
+    out.push(item);
+  }
+  return out;
+}
+
+function collectBurstListenerItems(attacker, burstee, skipItemId, usedSkills = []) {
+  const out = [];
+  const seen = new Set();
+  for (const owner of [attacker, burstee]) {
+    if (!owner?.items) continue;
+    for (const item of [
+      ...getEquippedItems(owner).filter((i) => i.type !== "skill"),
+      ...collectUsedSkills(owner, usedSkills),
+      ...uniqueStatusItems(owner.items),
+    ]) {
+      if (!item?.id || item.id === skipItemId) continue;
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      out.push({ item, owner });
+    }
+  }
+  return out;
+}
+
 // ── [On Burst] ────────────────────────────────────────────────────────────────
 // Fires when a Rupture/Tremor/other burst triggers.
 // Burst state lives on context.burst (status / amount / before / after).
@@ -819,6 +863,8 @@ export async function emitStatusBurst({
   attacker = null,
   clash = null,
   sourceItem = null,
+  attackerSkill = null,
+  defenderSkill = null,
   depth = 0,
 } = {}) {
   const name = String(statusName ?? "").trim();
@@ -851,6 +897,8 @@ export async function emitStatusBurst({
     self: actor,
     target: actor,
     attacker: attacker ?? null,
+    attackerSkill: attackerSkill ?? clash?.attackerSkill ?? null,
+    defenderSkill: defenderSkill ?? clash?.defenderSkill ?? null,
     ally: null,
     clash: clash ?? null,
     item: statusItem,
@@ -869,7 +917,7 @@ export async function emitStatusBurst({
 
   burst.after = Number(actor.getStatusStacks?.(name) ?? 0) || 0;
 
-  const listeners = collectBurstListenerItems(attacker, actor, statusItem.id);
+  const listeners = collectBurstListenerItems( attacker, actor, statusItem.id, usedSkillsFromContext({ sourceItem, attackerSkill, defenderSkill, clash }));
   for (const { item, owner } of listeners) {
     const globalCtx = {
       self: owner,
@@ -948,6 +996,8 @@ export async function emitProc({
   target = null,
   clash = null,
   sourceItem = null,
+  attackerSkill = null,
+  defenderSkill = null,
   binds = {},
   depth = 0,
 } = {}) {
@@ -990,7 +1040,7 @@ export async function emitProc({
   }
 
   const skipItemId = statusItem?.id ?? null;
-  const listeners = collectBurstListenerItems(proccer, focusActor, skipItemId);
+  const listeners = collectBurstListenerItems( proccer, focusActor, skipItemId, usedSkillsFromContext({ sourceItem, attackerSkill, defenderSkill, clash }) );
   for (const { item, owner } of listeners) {
     const globalCtx = {
       self: owner,

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -111,6 +111,22 @@ function collectSideClashItems(actor, usedItem, appliedTool, declaredSkill) {
   return out;
 }
 
+function clashUsedStatBlocks({
+  attackerItem,
+  defenderItem,
+  appliedTool,
+  defenderAppliedTool,
+  attackerSkill,
+  defenderSkill,
+  side = "all",
+} = {}) {
+  const attackerSide = usedStatBlockItems(attackerItem, appliedTool, attackerSkill);
+  const defenderSide = usedStatBlockItems(defenderItem, defenderAppliedTool, defenderSkill);
+  if (side === "attacker") return attackerSide;
+  if (side === "defender") return defenderSide;
+  return [...attackerSide, ...defenderSide];
+}
+
 function clashStartedItems({
   attacker = null,
   defender = null,
@@ -345,6 +361,7 @@ const TRIGGER_HOOKS = [
         self: defender,
         target: attacker ?? null,
         attacker: attacker ?? null,
+        attackerSkill: attackerSkill ?? clash?.attackerSkill ?? null,
         ally: null,
         clash: clash ?? createClashContext(),
       };
@@ -1031,27 +1048,6 @@ function findStatusItem(actor, statusName) {
   return uniqueStatusItems(actor.items).find(
     (i) => String(i.name ?? "").trim().toLowerCase() === want
   ) ?? null;
-}
-
-/**
- * @param {Actor|null|undefined} attacker
- * @param {Actor} burstee
- * @param {string} skipItemId
- * @returns {{ item: Item, owner: Actor }[]}
- */
-function collectBurstListenerItems(attacker, burstee, skipItemId) {
-  const out = [];
-  const seen = new Set();
-  for (const owner of [attacker, burstee]) {
-    if (!owner?.items) continue;
-    for (const item of [...getEquippedItems(owner), ...uniqueStatusItems(owner.items)]) {
-      if (!item?.id || item.id === skipItemId) continue;
-      if (seen.has(item.id)) continue;
-      seen.add(item.id);
-      out.push({ item, owner });
-    }
-  }
-  return out;
 }
 
 // ── [Always Active] integration ───────────────────────────────────────────────

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -73,30 +73,39 @@ function getAST(item) {
 
 Hooks.on("updateItem", (item) => _astCache.delete(item.id));
 
-function isPassiveClashItem(item, npcLoadout) {
+function isPassiveClashItem(item) {
   if (!item) return false;
   if (item.type === "augment") return true;
-  if (item.type === "outfit") return npcLoadout || item.system?.equipped === true;
+  if (item.type === "outfit") return item.system?.equipped === true;
   return false;
+}
+
+function itemIsLoadoutActive(item, actor) {
+  if (!item) return false;
+  if (item.type === "augment") return true;
+  if (item.type === "tool") return !!item.system?.equipped && isToolPresent(item);
+  if (item.type === "skill") return actor?.type === "npc" || item.system?.equipped === true;
+  if (item.type === "weapon" || item.type === "outfit") return item.system?.equipped === true;
+  return false;
+}
+
+function addUniqueItem(out, seen, item) {
+  if (!item) return;
+  const key = item.id || item.uuid;
+  if (!key || seen.has(key)) return;
+  seen.add(key);
+  out.push(item);
 }
 
 function collectSideClashItems(actor, usedItem, appliedTool, declaredSkill) {
   const out = [];
   const seen = new Set();
-  const add = (item) => {
-    if (!item) return;
-    const key = item.id || item.uuid;
-    if (!key || seen.has(key)) return;
-    seen.add(key);
-    out.push(item);
-  };
-  add(usedItem);
-  add(appliedTool);
-  add(declaredSkill);
+  addUniqueItem(out, seen, usedItem);
+  addUniqueItem(out, seen, appliedTool);
+  addUniqueItem(out, seen, declaredSkill);
   if (actor?.items) {
-    const npcLoadout = actor.type === "npc";
     for (const item of actor.items) {
-      if (isPassiveClashItem(item, npcLoadout)) add(item);
+      if (isPassiveClashItem(item)) addUniqueItem(out, seen, item);
     }
   }
   return out;
@@ -1070,15 +1079,12 @@ export function applyAlwaysActiveModifiers(actor) {
     );
   }
 
-  const npcLoadout = actor.type === "npc";
   for (const item of actor.items) {
     const isStatus = item.type === "status";
     if (!isStatus && !["weapon", "outfit", "augment", "skill", "tool"].includes(item.type)) continue;
     if (isStatus) {
       if (isPendingStatus(item)) continue;
-    } else if (item.type === "tool") {
-      if (!item.system?.equipped || !isToolPresent(item)) continue;
-    } else if (item.type !== "augment" && !npcLoadout && !item.system?.equipped) {
+    } else if (!itemIsLoadoutActive(item, actor)) {
       continue;
     }
 
@@ -1179,11 +1185,8 @@ export async function runOnTakingDamage(actor, damage, options = {}) {
  * Returns all equipped weapons, outfits, skills, tools, and augments on an actor.
  */
 function getEquippedItems(actor) {
-  const npcLoadout = actor.type === "npc";
   return actor.items.filter(i => {
     if (!["weapon", "outfit", "skill", "augment", "tool"].includes(i.type)) return false;
-    if (i.type === "tool") return !!i.system?.equipped && isToolPresent(i);
-    if (i.type === "augment") return true;
-    return npcLoadout || i.system?.equipped === true;
+    return itemIsLoadoutActive(i, actor);
   });
 }

--- a/src/module/rolls.js
+++ b/src/module/rolls.js
@@ -49,7 +49,7 @@ export class PMTTRPGRolls {
 
     return items
       .map(item => {
-        const isEquipped = actor.type === "npc" || !!item.system?.equipped;
+        const isEquipped = !!item.system?.equipped;
         const formula = isAttack
           ? (item.system?.offensiveDiceComputed || '1d10')
           : (skillType === 'block'

--- a/src/packs/status-pmttrpg-srd/Bind_qHdu1Iw1i1BAb8D0.yml
+++ b/src/packs/status-pmttrpg-srd/Bind_qHdu1Iw1i1BAb8D0.yml
@@ -19,6 +19,9 @@ system:
   easyEffects: |-
     [Always Active]
     lose (Bind) movement;
+
+    [End of Round]
+    lose all Bind;
 effects: []
 folder: jtSvJ9E0Hm5t7NVJ
 sort: 200000

--- a/src/packs/status-pmttrpg-srd/Haste_PlDRULSweu7CXNXh.yml
+++ b/src/packs/status-pmttrpg-srd/Haste_PlDRULSweu7CXNXh.yml
@@ -19,6 +19,9 @@ system:
   easyEffects: |-
     [Always Active]
     gain (Haste) movement;
+
+    [End of Round]
+    lose all Haste;
 effects: []
 folder: jtSvJ9E0Hm5t7NVJ
 sort: 150000

--- a/src/packs/status-pmttrpg-srd/Sinking_rxh17elwJWwlzJmB.yml
+++ b/src/packs/status-pmttrpg-srd/Sinking_rxh17elwJWwlzJmB.yml
@@ -25,7 +25,10 @@ system:
     burst Sinking on self
 
     [On Burst]
-    deal (burst.amount) sp damage to self
+    require (self.sp.max) == 0 then
+      deal (burst.amount) hp damage to self
+    require (self.sp.max) != 0 then
+      deal (burst.amount) sp damage to self
     lose all Sinking on self
 
     [End of Round]

--- a/src/templates/items/ammunition-sheet.html
+++ b/src/templates/items/ammunition-sheet.html
@@ -62,10 +62,6 @@
               </select>
             </div>
             <div class="resource">
-              <label>{{localize "PMTTRPG.Weight"}}</label>
-              <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number"/>
-            </div>
-            <div class="resource">
               <label>{{localize "PMTTRPG.Price"}}</label>
               <input type="text" name="system.price" value="{{system.price}}" data-dtype="Number"/>
             </div>


### PR DESCRIPTION
## Summary

Bunch of small combat / EasyEffects fixes that the community called out day one.

- Sinking burst deals HP when the target has no SP (not current SP). You can now read `(self.sp.max)` and walk actor paths in EE now.
- `[On Use]` runs off the weapon/outfit (and applied tool / skill) that was used now.
- Skills used as this Action/Reaction can now properly listen to `[On Burst]` / procs.
- One-sided hits now don't run the recipient's `Clash Lose` EE scripts.
- NPCs now have to equip items similarly to PCs
- Swift Recycled Evade now properly steps by 1 instead of 2.
- Ammo sheet no longer has Weight (old DW stuff).
- `per` works on `gain` / `lose` / `inflict` (statuses and resources), including Always Active (be sure not to add dice though as that intentionally doesn't work)
- Bind/Haste `[Always Active]` now properly changes movement.
- Fixed the movement Ruler and sheet information to no longer reset movement per turn.

## Related issue
Closes #93
Closes #94
Closes #95
Closes #96
Closes #97
Closes #98
Closes #101
Closes #106 

## Testing
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated (if applicable)