### PR TITLE
Multiple Augments & Augment Activation/Deactivation

### DIFF
--- a/src/module/actor/actor-npc-sheet.js
+++ b/src/module/actor/actor-npc-sheet.js
@@ -29,6 +29,7 @@ export class PMTTRPGActorNpcSheet extends PMTTRPGCharacterSheet {
       itemEdit: PMTTRPGCharacterSheet.prototype._onItemEdit,
       itemDelete: PMTTRPGCharacterSheet.prototype._onItemDelete,
       itemEquip: PMTTRPGCharacterSheet.prototype._onEquipEquipment,
+      augmentActivate: PMTTRPGCharacterSheet.prototype._onAugmentActivate,
       toggleDetails: PMTTRPGCharacterSheet.prototype._onToggleDetails,
       counterIncrease: PMTTRPGCharacterSheet.prototype._onCounterIncrease,
       counterDecrease: PMTTRPGCharacterSheet.prototype._onCounterDecrease,
@@ -117,10 +118,6 @@ export class PMTTRPGActorNpcSheet extends PMTTRPGCharacterSheet {
   async _onItemCreate(event, target) {
     event.preventDefault();
     const type = target.dataset.type;
-    if (type === "augment" && this.actor.items.some(item => item.type === "augment")) {
-      ui.notifications.warn(game.i18n.localize("PMTTRPG.AugmentOnlyOne"));
-      return;
-    }
     const data = foundry.utils.duplicate(target.dataset);
     const itemName = data.name || game.i18n.localize(`TYPES.Item.${type}`) || type;
     delete data.action;

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -82,6 +82,7 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
       itemEdit: PMTTRPGCharacterSheet.prototype._onItemEdit,
       itemDelete: PMTTRPGCharacterSheet.prototype._onItemDelete,
       itemEquip: PMTTRPGCharacterSheet.prototype._onEquipEquipment,
+      augmentActivate: PMTTRPGCharacterSheet.prototype._onAugmentActivate,
       toggleDetails: PMTTRPGCharacterSheet.prototype._onToggleDetails,
       counterIncrease: PMTTRPGCharacterSheet.prototype._onCounterIncrease,
       counterDecrease: PMTTRPGCharacterSheet.prototype._onCounterDecrease,
@@ -212,7 +213,6 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
         return augment;
       })
       .sort((a, b) => (a.sort || 0) - (b.sort || 0));
-    context.augment = context.augments[0] ?? null;
     context.statuses = this._prepareStatusItems(context.items);
 
     context.system.isToken = this.actor.isToken;
@@ -956,10 +956,6 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
   async _onItemCreate(event, target) {
     event.preventDefault();
     const type = target.dataset.type;
-    if (type === "augment" && this.actor.items.some(item => item.type === "augment")) {
-      ui.notifications.warn(game.i18n.localize("PMTTRPG.AugmentOnlyOne"));
-      return;
-    }
     const data = foundry.utils.duplicate(target.dataset);
     const itemName = data.name || game.i18n.localize(`TYPES.Item.${type}`) || type;
     delete data.action;
@@ -995,6 +991,20 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
     const currentlyOn = !!(source.equipped || source.held || item.system?.equipped);
     const update = { "system.equipped": !currentlyOn };
     if (item.type === "tool") update["system.held"] = foundry.data.operators.ForcedDeletion;
+    await item.update(update);
+  }
+
+  async _onAugmentActivate(event, target) {
+    event.preventDefault();
+    event.stopPropagation();
+    const itemId = this._itemIdFor(target);
+    const item = itemId ? this.actor.items.get(itemId) : null;
+    if (!item) return;
+
+    // Prefer source so a leftover system.held overlay can't invert the toggle.
+    const source = item._source?.system ?? {};
+    const currentlyOn = !!(source.active);
+    const update = { "system.active": !currentlyOn };
     await item.update(update);
   }
 
@@ -1228,11 +1238,6 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
   async _onDropItem(event, item) {
     if (!item) return null;
     if (item.parent?.id === this.actor.id) return null;
-
-    if (item.type === "augment" && this.actor.items.some(owned => owned.type === "augment")) {
-      ui.notifications.warn(game.i18n.localize("PMTTRPG.AugmentOnlyOne"));
-      return null;
-    }
 
     if (item.type === "status") {
       const stacks = Math.max(0, Math.trunc(Number(item.system?.stacks ?? 1) || 0));

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -108,14 +108,14 @@ function resolveOwnedItem(actor, item) {
 function isPassiveClashItem(item) {
   if (!item) return false;
   if (item.type === "weapon" || item.type === "skill") return false;
-  if (item.type === "augment") return true;
+  if (item.type === "augment") return item.system?.active === true;
   if (item.type === "outfit") return item.system?.equipped === true;
   return false;
 }
 
 function itemIsLoadoutActive(item, actor) {
   if (!item) return false;
-  if (item.type === "augment") return true;
+  if (item.type === "augment") return item.system?.active === true;
   if (item.type === "tool") return !!item.system?.equipped && isToolPresent(item);
   if (item.type === "skill") return actor?.type === "npc" || item.system?.equipped === true;
   if (item.type === "weapon" || item.type === "outfit") return item.system?.equipped === true;

--- a/src/styles/lib/character-sheet.css
+++ b/src/styles/lib/character-sheet.css
@@ -2090,6 +2090,12 @@
   display: none;
 }
 
+.pm-sheet .item--weapon-unequipped,
+.pm-sheet .item--outfit-unequipped,
+.pm-sheet .item--augment-inactive {
+  filter: grayscale(1);
+}
+
 .pm-sheet .item-count {
   font-size: 0.92em;
   font-weight: 600;

--- a/src/templates/sheet/character/partials/augment.hbs
+++ b/src/templates/sheet/character/partials/augment.hbs
@@ -1,44 +1,31 @@
-<section class="equipment-section equipment-section--augment">
-  <header class="tab-section-header">
-    <h3 class="tab-section-title">{{localize "PMTTRPG.Augment"}}</h3>
-    {{#unless augment}}
-    <button type="button" data-action="itemCreate" data-type="augment">{{localize "PMTTRPG.AddAugment"}}</button>
-    {{/unless}}
-  </header>
-
-  {{#if augment}}
-  <ol class="items-list">
-    <li class="item item--augment" data-item-id="{{augment._id}}">
-      <div class="item-title-row">
-        <div class="item-title-row__lead">
-          {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=augment.img name=augment.name}}
-          <strong class="item-name">{{augment.name}}</strong>
-        </div>
-        <div class="item-controls">
-          {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-controls-augment.hbs" itemId=augment._id}}
-        </div>
+{{#if augment}}
+  <li class="item item--augment {{#if augment.system.active}}{{else}}item--augment-inactive{{/if}}" data-item-id="{{augment._id}}">
+    <div class="item-title-row">
+      <div class="item-title-row__lead">
+        {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=augment.img name=augment.name}}
+        <strong class="item-name">{{augment.name}}</strong>
       </div>
-      <div class="item-details">
-        <div class="item-tags">
-          {{#if augment.system.rank}}
-            <span class="tag tag--rank">{{localize "PMTTRPG.AugmentRank"}}: {{augment.system.rank}}</span>
-          {{/if}}
-        </div>
-        {{#if augment.system.descriptionEnriched}}
-        <div class="item-flavor description">{{{augment.system.descriptionEnriched}}}</div>
-        {{/if}}
-        {{#if augment.system.effectSummaryGroups.length}}
-          {{#with (lookup augment.system.effectSummaryGroups 0) as |group|}}
-          <div class="item-effect-summary">
-            <h4 class="item-effect-summary__title">{{group.heading}}</h4>
-            <div class="item-effect-summary__body">{{{group.summaryText}}}</div>
-          </div>
-          {{/with}}
+      <div class="item-controls">
+        {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-controls-augment.hbs" itemId=augment._id active=augment.system.active}}
+      </div>
+    </div>
+    <div class="item-details">
+      <div class="item-tags">
+        {{#if augment.system.rank}}
+          <span class="tag tag--rank">{{localize "PMTTRPG.AugmentRank"}}: {{augment.system.rank}}</span>
         {{/if}}
       </div>
-    </li>
-  </ol>
-  {{else}}
-  <p class="tab-empty">{{localize "PMTTRPG.NoAugments"}}</p>
-  {{/if}}
-</section>
+      {{#if augment.system.descriptionEnriched}}
+      <div class="item-flavor description">{{{augment.system.descriptionEnriched}}}</div>
+      {{/if}}
+      {{#if augment.system.effectSummaryGroups.length}}
+        {{#with (lookup augment.system.effectSummaryGroups 0) as |group|}}
+        <div class="item-effect-summary">
+          <h4 class="item-effect-summary__title">{{group.heading}}</h4>
+          <div class="item-effect-summary__body">{{{group.summaryText}}}</div>
+        </div>
+        {{/with}}
+      {{/if}}
+    </div>
+  </li>
+{{/if}}

--- a/src/templates/sheet/character/partials/item-controls-augment.hbs
+++ b/src/templates/sheet/character/partials/item-controls-augment.hbs
@@ -1,2 +1,15 @@
+<button type="button"
+        class="item-control tool-equip{{#if active}} tool-equip--on{{else}} tool-equip--stowed{{/if}}"
+        data-action="augmentActivate"
+        data-item-id="{{itemId}}"
+        title=""
+        aria-label=""
+        aria-pressed="{{#if active}}true{{else}}false{{/if}}">
+    {{#if active}}
+    <i class="fa-solid fa-square-check"></i>
+    {{else}}
+    <i class="fa-solid fa-square-xmark"></i>
+    {{/if}}
+</button>
 <button type="button" class="item-control" data-action="itemEdit" data-item-id="{{itemId}}" title="{{localize "PMTTRPG.Common.EditItem"}}" aria-label="{{localize "PMTTRPG.Common.EditItem"}}"><i class="fas fa-edit" aria-hidden="true"></i></button>
 <button type="button" class="item-control" data-action="itemDelete" data-item-id="{{itemId}}" title="{{localize "PMTTRPG.Common.DeleteItem"}}" aria-label="{{localize "PMTTRPG.Common.DeleteItem"}}"><i class="fas fa-trash" aria-hidden="true"></i></button>

--- a/src/templates/sheet/character/partials/item-row-outfit.hbs
+++ b/src/templates/sheet/character/partials/item-row-outfit.hbs
@@ -1,4 +1,4 @@
-<li class="item item--outfit collapsed{{#if item.system.equipped}} item--equipped{{/if}}" data-item-id="{{item._id}}">
+<li class="item item--outfit collapsed{{#if item.system.equipped}} item--equipped{{else}} item--outfit-unequipped{{/if}}" data-item-id="{{item._id}}">
   <div class="item-title-row">
     <div class="item-title-row__lead">
       {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=item.img name=item.name}}

--- a/src/templates/sheet/character/partials/item-row-weapon.hbs
+++ b/src/templates/sheet/character/partials/item-row-weapon.hbs
@@ -1,4 +1,4 @@
-<li class="item item--weapon collapsed{{#if item.system.equipped}} item--equipped{{/if}}" data-item-id="{{item._id}}">
+<li class="item item--weapon collapsed{{#if item.system.equipped}} item--equipped{{else}} item--weapon-unequipped{{/if}}" data-item-id="{{item._id}}">
   <div class="item-title-row">
     <div class="item-title-row__lead">
       {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=item.img name=item.name}}

--- a/src/templates/sheet/character/partials/tab-augment.hbs
+++ b/src/templates/sheet/character/partials/tab-augment.hbs
@@ -1,3 +1,15 @@
 <div class="tab-scroll augment-tab">
-  {{> "systems/projectmoonttrpg/templates/sheet/character/partials/augment.hbs"}}
+  <section class="equipment-section equipment-section--augment">
+    <header class="tab-section-header">
+      <h3 class="tab-section-title">{{localize "PMTTRPG.Augment"}}</h3>
+      <button type="button" data-action="itemCreate" data-type="augment">{{localize "PMTTRPG.AddAugment"}}</button>
+    </header>
+  <ol class="items-list">
+  {{#each augments as |augment|}}
+    {{> "systems/projectmoonttrpg/templates/sheet/character/partials/augment.hbs" augment=augment}}
+  {{else}}
+    <p class="tab-empty">{{localize "PMTTRPG.NoAugments"}}</p>
+  {{/each}}
+  </ol>
+  </section>
 </div>

--- a/src/templates/sheet/npc/partials/item-controls-loadout.hbs
+++ b/src/templates/sheet/npc/partials/item-controls-loadout.hbs
@@ -19,6 +19,21 @@
   {{/if}}
 </button>
 {{/if}}
+{{#if activable}}
+<button type="button"
+        class="item-control tool-equip{{#if active}} tool-equip--on{{else}} tool-equip--stowed{{/if}}"
+        data-action="augmentActivate"
+        data-item-id="{{itemId}}"
+        title=""
+        aria-label=""
+        aria-pressed="{{#if active}}true{{else}}false{{/if}}">
+    {{#if active}}
+    <i class="fa-solid fa-square-check"></i>
+    {{else}}
+    <i class="fa-solid fa-square-xmark"></i>
+    {{/if}}
+</button>
+{{/if}}
 {{#unless locked}}
 <button type="button" class="item-control" data-action="itemEdit" data-item-id="{{itemId}}" title="{{localize "PMTTRPG.Common.EditItem"}}" aria-label="{{localize "PMTTRPG.Common.EditItem"}}"><i class="fas fa-edit" aria-hidden="true"></i></button>
 <button type="button" class="item-control" data-action="itemDelete" data-item-id="{{itemId}}" title="{{localize "PMTTRPG.Common.DeleteItem"}}" aria-label="{{localize "PMTTRPG.Common.DeleteItem"}}"><i class="fas fa-trash" aria-hidden="true"></i></button>

--- a/src/templates/sheet/npc/partials/item-row-augment.hbs
+++ b/src/templates/sheet/npc/partials/item-row-augment.hbs
@@ -1,11 +1,11 @@
-<li class="item item--augment item--loadout collapsed" data-item-id="{{item._id}}">
+<li class="item item--augment item--loadout collapsed {{#if item.system.active}}{{else}}item--augment-inactive{{/if}}" data-item-id="{{item._id}}">
   <div class="item-title-row">
     <div class="item-title-row__lead">
       {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=item.img name=item.name}}
       <strong class="item-name">{{item.name}}</strong>
     </div>
     <div class="item-controls">
-      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=false}}
+      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=false activable=true active=item.system.active}}
     </div>
   </div>
   <div class="item-details">

--- a/src/templates/sheet/npc/partials/item-row-outfit.hbs
+++ b/src/templates/sheet/npc/partials/item-row-outfit.hbs
@@ -1,4 +1,4 @@
-<li class="item item--outfit item--loadout collapsed" data-item-id="{{item._id}}">
+<li class="item item--outfit item--loadout collapsed {{#if item.system.equipped}}{{else}}item--outfit-unequipped{{/if}}" data-item-id="{{item._id}}">
   <div class="item-title-row">
     <div class="item-title-row__lead">
       {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=item.img name=item.name}}
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="item-controls">
-      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=true equipped=item.system.equipped mode="wear"}}
+      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=true equipped=item.system.equipped mode="wear" activable=false}}
     </div>
   </div>
   <div class="item-details">

--- a/src/templates/sheet/npc/partials/item-row-weapon.hbs
+++ b/src/templates/sheet/npc/partials/item-row-weapon.hbs
@@ -1,4 +1,4 @@
-<li class="item item--weapon item--loadout collapsed" data-item-id="{{item._id}}">
+<li class="item item--weapon item--loadout collapsed {{#if item.system.equipped}}{{else}}item--weapon-unequipped{{/if}}" data-item-id="{{item._id}}">
   <div class="item-title-row">
     <div class="item-title-row__lead">
       {{> "systems/projectmoonttrpg/templates/sheet/character/partials/item-thumb.hbs" img=item.img name=item.name}}
@@ -10,7 +10,7 @@
       </div>
     </div>
     <div class="item-controls">
-      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=true equipped=item.system.equipped handProperty=item.system.handProperty}}
+      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-controls-loadout.hbs" itemId=item._id locked=locked equippable=true equipped=item.system.equipped handProperty=item.system.handProperty activable=false}}
     </div>
   </div>
   <div class="item-details">

--- a/src/templates/sheet/npc/partials/tab-combat.hbs
+++ b/src/templates/sheet/npc/partials/tab-combat.hbs
@@ -244,22 +244,20 @@
   </section>
   {{/unless}}
 
-  {{#unless (or (not augment)) }}
+  {{#unless (or (eq augments.length 0)) }}
   <section class="equipment-section equipment-section--augment">
     <header class="tab-section-header">
       <h3 class="tab-section-title">{{localize "PMTTRPG.Augment"}}</h3>
       {{#unless locked}}
-        {{#unless augment}}
         <button type="button" data-action="itemCreate" data-type="augment">{{localize "PMTTRPG.AddAugment"}}</button>
-        {{/unless}}
       {{/unless}}
     </header>
     <ol class="items-list">
-      {{#if augment}}
-      {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-row-augment.hbs" item=augment selects=selects locked=locked}}
+      {{#each augments as |augment|}}
+        {{> "systems/projectmoonttrpg/templates/sheet/npc/partials/item-row-augment.hbs" item=augment selects=selects locked=locked}}
       {{else}}
-      <li class="tab-empty-item"><p class="tab-empty">{{localize "PMTTRPG.Augment"}} — {{localize "PMTTRPG.None"}}</p></li>
-      {{/if}}
+        <li class="tab-empty-item"><p class="tab-empty">{{localize "PMTTRPG.Augment"}} — {{localize "PMTTRPG.None"}}</p></li>
+      {{/each}}
     </ol>
   </section>
   {{else if editMode}}
@@ -267,9 +265,7 @@
     <header class="tab-section-header">
       <h3 class="tab-section-title">{{localize "PMTTRPG.Augment"}}</h3>
       {{#unless locked}}
-        {{#unless augment}}
         <button type="button" data-action="itemCreate" data-type="augment">{{localize "PMTTRPG.AddAugment"}}</button>
-        {{/unless}}
       {{/unless}}
     </header>
   </section>

--- a/src/yaml/template.yml
+++ b/src/yaml/template.yml
@@ -351,6 +351,7 @@ Item:
     effects: []
     customNotes: ''
     easyEffects: ''
+    active: true
   effect:
     templates:
       - base


### PR DESCRIPTION
## Summary

- Removed the limit of 1 Augment per Actor.
- Augments can now be activated/deactivated at will (with EE integration!)
- Weapons, Outfits and Augments that are unequipped/inactive now show up in grayscale.

## Related issue

Closes #147 

## Testing

- [X] Tested locally
- [X] No console errors

## Screenshots

<img width="578" height="553" alt="image" src="https://github.com/user-attachments/assets/3a0fb19f-84cf-4461-8b73-b1bae9322925" />
<img width="571" height="432" alt="image" src="https://github.com/user-attachments/assets/27e4aec7-9af9-4a18-848e-9a1baf3bf42e" />
<img width="643" height="180" alt="image" src="https://github.com/user-attachments/assets/8d9f9904-7088-4ad3-9f2d-60c498c09ecd" />
<img width="635" height="162" alt="image" src="https://github.com/user-attachments/assets/af9bb5e0-2d7f-40e1-b35a-63a60cca177d" />
