### PR TITLE
Implement Clash Action Economy and fixed other things

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -2,7 +2,7 @@ import { PMTTRPGUtility } from '../utility.js';
 import { getActionEconomyFromRank, getRankFromLevel, TACTICAL_SQUARES_BASE, squareTurnCap } from './progression.js';
 import { actorHistorySquareCost, actorSquaresExhausted } from '../combat/movement.js';
 const { renderTemplate } = foundry.applications.handlebars;
-import { applyAlwaysActiveModifiers, runOnTakingDamage, runDepletedEasyEffects } from '../easy-effects/registry.js';
+import { applyAlwaysActiveModifiers, emitActorAction, runOnTakingDamage, runDepletedEasyEffects } from '../easy-effects/registry.js';
 import { applyResourceModsToSystem, applyResourceOverridesToSystem } from '../easy-effects/nouns.js';
 import { applyInventorySlotUsage } from '../inventory/slots.js';
 import { isPendingStatus, normalizeArrival } from '../status/pending.js';
@@ -369,9 +369,10 @@ export class ActorPMTTRPG extends Actor {
    * Spend from an action-economy pool.
    * @param {"actions"|"reactions"|"movement"} poolKey
    * @param {number} [amount=1]
+   * @param {{ warn?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
-  async spendActionEconomy(poolKey, amount = 1) {
+  async spendActionEconomy(poolKey, amount = 1, { warn = true } = {}) {
     const allowed = new Set(['actions', 'reactions', 'movement']);
     if (!allowed.has(poolKey)) {
       throw new Error(`Invalid action economy pool: ${poolKey}`);
@@ -382,19 +383,46 @@ export class ActorPMTTRPG extends Actor {
     if (spent === 0) return false;
     const current = Number(pool.value) || 0;
     if (current < spent) {
-      ui.notifications.warn(game.i18n.format('PMTTRPG.Notifications.actionEconomyInsufficient', {
-        name: this.name,
-        pool: game.i18n.localize({
-          actions: 'PMTTRPG.Actions',
-          reactions: 'PMTTRPG.Reactions',
-          movement: 'PMTTRPG.Movement',
-        }[poolKey]),
-        current,
-        needed: spent,
-      }));
+      if (warn) {
+        ui.notifications.warn(game.i18n.format('PMTTRPG.Notifications.actionEconomyInsufficient', {
+          name: this.name,
+          pool: game.i18n.localize({
+            actions: 'PMTTRPG.Actions',
+            reactions: 'PMTTRPG.Reactions',
+            movement: 'PMTTRPG.Movement',
+          }[poolKey]),
+          current,
+          needed: spent,
+        }));
+      }
       return false;
     }
     await this.update({ [`system.attributes.${poolKey}.value`]: current - spent });
+    return true;
+  }
+
+  /**
+   * Spend 1 Action or Reaction and run [On Action].
+   * @param {"action"|"reaction"} kind
+   * @param {object} [payload]
+   * @param {{ warn?: boolean }} [options]
+   * @returns {Promise<boolean>}
+   */
+  async useActionEconomy(kind, payload = {}, { warn = true } = {}) {
+    const actionType = kind === "reaction" ? "reaction" : "action";
+    const poolKey = actionType === "reaction" ? "reactions" : "actions";
+    const spent = await this.spendActionEconomy(poolKey, 1, { warn });
+    if (!spent && warn) return false;
+    try {
+      await emitActorAction({
+        ...payload,
+        actor: this,
+        actorId: this.id,
+        actionType,
+      });
+    } catch (error) {
+      console.warn("[EasyEffects] actorAction hook failed", error);
+    }
     return true;
   }
 

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -5,7 +5,6 @@ import { buildEffectSummaryGroups } from "../effects/effect-summary.js";
 import { groupStatuses } from "../status/group-statuses.js";
 import { isPendingStatus } from "../status/pending.js";
 import { EasyEffectsEditor } from "../apps/easy-effects-editor.js";
-import { emitActorAction } from "../easy-effects/registry.js";
 import { buildEffectiveResistanceDisplay, DAMAGE_TYPES } from "../damage-application.js";
 
 const { ActorSheetV2 } = foundry.applications.sheets;
@@ -913,18 +912,7 @@ export class PMTTRPGCharacterSheet extends HandlebarsApplicationMixin(ActorSheet
     event.preventDefault();
     if (!this.actor.isOwner) return;
     const kind = target?.dataset?.kind === "reaction" ? "reaction" : "action";
-    const poolKey = kind === "reaction" ? "reactions" : "actions";
-    const spent = await this.actor.spendActionEconomy(poolKey, 1);
-    if (!spent) return;
-    try {
-      await emitActorAction({
-        actor: this.actor,
-        actorId: this.actor.id,
-        actionType: kind,
-      });
-    } catch (error) {
-      console.warn("[EasyEffects] actorAction hook failed", error);
-    }
+    await this.actor.useActionEconomy(kind);
   }
 
   async _onEditImage(event, target) {

--- a/src/module/combat/clash-rolls.js
+++ b/src/module/combat/clash-rolls.js
@@ -1,4 +1,6 @@
 import { applyDiceMaxFloor, formatDiceFormula} from "../easy-effects/dice-formula.js";
+import { addCombatDiceMods } from "../easy-effects/nouns.js";
+import { getItemAlwaysActiveCombatMods } from "../easy-effects/registry.js";
 import { normalizeWeaponProperties } from "../item/weapon-properties.js";
 
 /**
@@ -93,8 +95,11 @@ export function buildOffensiveDiceParts(actor, weaponItem, clashBonuses = {}) {
 
   const rank = Number(actor?.system?.attributes?.rank?.value ?? 0) || 0;
   const eeMods = actor?.system?.attributes?.easyEffectsMods ?? {};
-  const alwaysPower = Number(eeMods.attackPower ?? 0) || 0;
-  const alwaysMax = Number(eeMods.attackMax ?? 0) || 0;
+  const local = weaponItem?.system?.alwaysActiveCombatMods
+    ?? getItemAlwaysActiveCombatMods(weaponItem, actor);
+  const always = addCombatDiceMods(eeMods, local);
+  const alwaysPower = Number(always.attackPower ?? 0) || 0;
+  const alwaysMax = Number(always.attackMax ?? 0) || 0;
   const clashPower = Number(clashBonuses.attackPower ?? 0) || 0;
   const clashMax = Number(clashBonuses.attackMax ?? 0) || 0;
 
@@ -192,8 +197,11 @@ export function buildDefenseDiceParts(actor, kind, clashBonuses = {}) {
     ? Number(actor?.system?.abilities?.ins?.value ?? 0) || 0
     : Number(actor?.system?.abilities?.tem?.value ?? 0) || 0;
   const eeMods = actor?.system?.attributes?.easyEffectsMods ?? {};
-  const alwaysPower = Number(isEvade ? eeMods.evadePower : eeMods.blockPower) || 0;
-  const alwaysMax = Number(isEvade ? eeMods.evadeMax : eeMods.blockMax) || 0;
+  const local = outfit?.system?.alwaysActiveCombatMods
+    ?? getItemAlwaysActiveCombatMods(outfit, actor);
+  const always = addCombatDiceMods(eeMods, local);
+  const alwaysPower = Number(isEvade ? always.evadePower : always.blockPower) || 0;
+  const alwaysMax = Number(isEvade ? always.evadeMax : always.blockMax) || 0;
   const clashPower = Number(isEvade ? clashBonuses.evadePower : clashBonuses.blockPower) || 0;
   const clashMax = Number(isEvade ? clashBonuses.evadeMax : clashBonuses.blockMax) || 0;
 

--- a/src/module/combat/clashing.js
+++ b/src/module/combat/clashing.js
@@ -6,6 +6,7 @@
  *   3. _executeClash()          — both rolls made, result computed
  *
  * EasyEffects hooks fired here:
+ *   pmttrpg.actorAction         [On Action] for Attack / Block / Counter / Evade
  *   pmttrpg.clashStarted       { attacker, defender, attackerItem, defenderItem, clash }
  *   pmttrpg.clashResolved      { winner, loser, attackerItem, defenderItem,
  *                                attackerRoll, defenderRoll, clash }
@@ -69,6 +70,12 @@ const REACTIONS_THAT_CLEAR_RECYCLED = new Set([
   RETALIATION_TYPES.EVADE,
   RETALIATION_TYPES.BLOCK,
   RETALIATION_TYPES.COUNTER,
+]);
+
+const REACTIONS_THAT_SPEND = new Set([
+  RETALIATION_TYPES.BLOCK,
+  RETALIATION_TYPES.COUNTER,
+  RETALIATION_TYPES.EVADE,
 ]);
 
 // ── Phase 1: Initiate Attack ──────────────────────────────────────────────────
@@ -339,6 +346,14 @@ async function _executeClash(state, retaliatorActor, choice) {
     clash:        clashCtx,
   };
 
+  await _spendClashActionEconomy({
+    attackerActor,
+    retaliatorActor,
+    choice,
+    isRecycled,
+    clash: clashCtx,
+  });
+
   await emitClashStarted({ ...clashPayloadBase, side: "attacker" });
   await emitClashStarted({ ...clashPayloadBase, side: "defender" });
 
@@ -559,6 +574,37 @@ async function _executeClash(state, retaliatorActor, choice) {
 
 function _isRangedWeapon(weapon) {
   return weapon?.system?.weaponType === "ranged";
+}
+
+/**
+ * Spend Action (attacker) or Reaction (block / counter / evade) and run [On Action].
+ */
+async function _spendClashActionEconomy({
+  attackerActor,
+  retaliatorActor,
+  choice,
+  isRecycled,
+  clash,
+}) {
+  const payload = {
+    attacker: attackerActor,
+    defender: retaliatorActor,
+    clash,
+  };
+  const silent = { warn: false };
+  if (attackerActor) {
+    await attackerActor.useActionEconomy("action", {
+      ...payload,
+      target: retaliatorActor,
+    }, silent);
+  }
+  if (isRecycled || !retaliatorActor) return;
+  if (!REACTIONS_THAT_SPEND.has(choice?.type)) return;
+  await retaliatorActor.useActionEconomy("reaction", {
+    ...payload,
+    target: attackerActor,
+    reactionType: choice.type,
+  }, silent);
 }
 
 function _reactionAppliedToolActionType(type) {

--- a/src/module/easy-effects/interpreter.js
+++ b/src/module/easy-effects/interpreter.js
@@ -39,6 +39,19 @@ function declareVariable(context, name, value) {
   context._eeVars.set(name, value);
 }
 
+function readAmountSnapshot(context, node) {
+  if (!node?.snapshot) return undefined;
+  const cache = context?._amountSnapshots;
+  if (!(cache instanceof WeakMap) || !cache.has(node)) return undefined;
+  return cache.get(node);
+}
+
+function writeAmountSnapshot(context, node, value) {
+  if (!node?.snapshot) return;
+  if (!(context._amountSnapshots instanceof WeakMap)) context._amountSnapshots = new WeakMap();
+  context._amountSnapshots.set(node, value);
+}
+
 async function evaluateExpr(node, context) {
   switch (node.type) {
     case "Num":   return node.value;
@@ -521,17 +534,26 @@ function coerceActorPathValue(value) {
 
 async function resolveAmount(amountNode, context) {
   if (!amountNode) return 1;
+  const cached = readAmountSnapshot(context, amountNode);
+  if (cached !== undefined) return cached;
+  let value;
   switch (amountNode.type) {
-    case "NUMBER":   return amountNode.value;
-    case "DICE":     return evaluateDiceFormula(amountNode.value, context);
-    case "ACCESSOR": return Number(await evaluateExpr(amountNode.expr, context)) || 0;
-    case "EFFECT_N": return Math.max(0, Number(context.effectN) || 0);
-    case "POOL_MAX": return 0; // resolved per-actor in set handler
+    case "NUMBER":   value = amountNode.value; break;
+    case "DICE":     value = await evaluateDiceFormula(amountNode.value, context); break;
+    case "ACCESSOR": value = Number(await evaluateExpr(amountNode.expr, context)) || 0; break;
+    case "EFFECT_N": value = Math.max(0, Number(context.effectN) || 0); break;
+    case "POOL_MAX": value = 0; break; // resolved per-actor in set handler
     case "MULTIPLIEDPATH":
-      return resolvePath(amountNode.path.segments, context)
+      value = resolvePath(amountNode.path.segments, context)
         * await resolveAmount(amountNode.multiplier, context);
-    default: console.warn(`[EasyEffects] Unknown amount type '${amountNode.type}'`); return 1;
+      break;
+    default:
+      console.warn(`[EasyEffects] Unknown amount type '${amountNode.type}'`);
+      value = 1;
+      break;
   }
+  writeAmountSnapshot(context, amountNode, value);
+  return value;
 }
 
 /**
@@ -566,17 +588,26 @@ async function resolveActionAmount(action, context) {
 
 function resolveAmountSync(amountNode, context) {
   if (!amountNode) return 1;
+  const cached = readAmountSnapshot(context, amountNode);
+  if (cached !== undefined) return cached;
+  let value;
   switch (amountNode.type) {
-    case "NUMBER":   return amountNode.value;
-    case "DICE":     console.warn("[EasyEffects] Dice not allowed in [Always Active]"); return 0;
-    case "ACCESSOR": return Number(evaluateExprSync(amountNode.expr, context)) || 0;
-    case "EFFECT_N": return Math.max(0, Number(context.effectN) || 0);
-    case "POOL_MAX": return 0;
+    case "NUMBER":   value = amountNode.value; break;
+    case "DICE":
+      console.warn("[EasyEffects] Dice not allowed in [Always Active]");
+      value = 0;
+      break;
+    case "ACCESSOR": value = Number(evaluateExprSync(amountNode.expr, context)) || 0; break;
+    case "EFFECT_N": value = Math.max(0, Number(context.effectN) || 0); break;
+    case "POOL_MAX": value = 0; break;
     case "MULTIPLIEDPATH":
-      return resolvePath(amountNode.path.segments, context)
+      value = resolvePath(amountNode.path.segments, context)
         * resolveAmountSync(amountNode.multiplier, context);
-    default: return 1;
+      break;
+    default: value = 1; break;
   }
+  writeAmountSnapshot(context, amountNode, value);
+  return value;
 }
 
 // ── Action handlers ───────────────────────────────────────────────────────────
@@ -1142,6 +1173,7 @@ async function resolveLhs(lhs, context) {
 
 async function resolveRhs(rhs, context) {
   if (!rhs) return 0;
+  if (rhs.snapshot) return resolveAmount(rhs, context);
   if (rhs.type === "NUMBER")   return rhs.value;
   if (rhs.type === "EFFECT_N") return Math.max(0, Number(context.effectN) || 0);
   if (rhs.type === "ACCESSOR") return evaluateExpr(rhs.expr, context);
@@ -1152,6 +1184,7 @@ async function resolveRhs(rhs, context) {
 
 function resolveRhsSync(rhs, context) {
   if (!rhs) return 0;
+  if (rhs.snapshot) return resolveAmountSync(rhs, context);
   if (rhs.type === "NUMBER")   return rhs.value;
   if (rhs.type === "EFFECT_N") return Math.max(0, Number(context.effectN) || 0);
   if (rhs.type === "ACCESSOR") return evaluateExprSync(rhs.expr, context);
@@ -1258,7 +1291,7 @@ export async function execute(ast, trigger, context) {
   const dialogDepth = Number(context?._dialogDepth) || 0;
   ensureRollsBag(context);
   // Fresh lets per execute() call. Dialog answers and concurrent runs stay isolated.
-  const execContext = { ...context, _eeVars: new Map(), _scriptAst: ast };
+  const execContext = { ...context, _eeVars: new Map(), _scriptAst: ast, _amountSnapshots: new WeakMap() };
 
   for (const block of ast.blocks) {
     if (block.trigger !== trigger) continue;
@@ -1488,6 +1521,7 @@ export function executeAlwaysActive(ast, prepareContext) {
     clash: null,
     combat: prepareContext.combat ?? globalThis.game?.combat ?? null,
     _eeVars: new Map(),
+    _amountSnapshots: new WeakMap(),
   };
 
   for (const block of ast.blocks) {

--- a/src/module/easy-effects/nouns.js
+++ b/src/module/easy-effects/nouns.js
@@ -363,6 +363,13 @@ export function resolvePathShorthand(actor, segment) {
   return null;
 }
 
+export const COMBAT_DICE_KEYS = [
+  "attackPower", "attackMax",
+  "blockPower", "blockMax",
+  "evadePower", "evadeMax",
+  "damagePower", "damageMax",
+];
+
 export function emptyAlwaysActiveMods() {
   const mods = {
     attackPower: 0, blockPower: 0, evadePower: 0, damagePower: 0,
@@ -380,6 +387,36 @@ export function emptyAlwaysActiveMods() {
     if (key && mods[key] === undefined) mods[key] = 0;
   }
   return mods;
+}
+
+/** Only grab the combat power/max modifiers. Weapon and outfit [Always Active] effects keep these on the item. */
+export function pickCombatDiceMods(mods) {
+  const out = {};
+
+  for (const key of COMBAT_DICE_KEYS) {
+    out[key] = Number(mods?.[key] ?? 0) || 0;
+  }
+
+  return out;
+}
+
+/** Copy the modifiers, but reset all combat dice modifiers to 0. */
+export function zeroCombatDiceMods(mods) {
+  const out = { ...mods };
+
+  for (const key of COMBAT_DICE_KEYS) out[key] = 0;
+
+  return out;
+}
+
+/** Combine the combat dice modifiers from two sets of modifiers. */
+export function addCombatDiceMods(a, b) {
+  const out = pickCombatDiceMods(a);
+  const extra = pickCombatDiceMods(b);
+
+  for (const key of COMBAT_DICE_KEYS) out[key] += extra[key];
+
+  return out;
 }
 
 export function applyResourceMod(mods, nounId, signedAmount) {

--- a/src/module/easy-effects/parser.js
+++ b/src/module/easy-effects/parser.js
@@ -2014,6 +2014,8 @@ class Parser {
     if (this.check("KEYWORD", "do")) this.consume("KEYWORD", "do");
     const gainActions = this.parseNaturalActionChain();
 
+    spendAmount.snapshot = true;
+
     const condition = {
       type: "Condition",
       lhs: { type: "ACCESSOR", expr: { type: "Path", segments: [spendTarget, "status", statusName] } },

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -1,6 +1,6 @@
 import { parse }                                    from "./parser.js";
 import { execute, executeAlwaysActive }             from "./interpreter.js";
-import { emptyAlwaysActiveMods }                    from "./nouns.js";
+import { emptyAlwaysActiveMods, pickCombatDiceMods, zeroCombatDiceMods } from "./nouns.js";
 import { isToolPresent }                            from "../inventory/slots.js";
 import { uniqueStatusItems }                        from "../status/group-statuses.js";
 import { isPendingStatus }                          from "../status/pending.js";
@@ -1394,6 +1394,9 @@ function findStatusItem(actor, statusName) {
  * Iterates all equipped items, runs their [Always Active] blocks synchronously,
  * and returns a merged modifier object.
  *
+ * Combat dice (power / max) from weapons and outfits stay on that item
+ * (see getItemAlwaysActiveCombatMods).
+ *
  * Usage in actor.js:
  *
  *   // At the end of _prepareCharacterData():
@@ -1402,7 +1405,6 @@ function findStatusItem(actor, statusName) {
  *   data.attributes.evadeModifier.value   += eeMods.evadePower;
  *   data.attributes.blockModifier.value   += eeMods.blockPower;
  *   applyResourceModsToSystem(data, eeMods);
- *   // damagePower / damageMax / attackMax etc. — apply to weapon dice fields
  *
  * @param {ActorPMTTRPG} actor
  * @returns {object} merged modifier object
@@ -1435,10 +1437,29 @@ export function applyAlwaysActiveModifiers(actor) {
     const hasAlwaysActive = ast.blocks.some(b => b.trigger === "Always Active");
     if (!hasAlwaysActive) continue;
 
-    mergeAlwaysActiveMods(merged, executeAlwaysActive(ast, { self: actor, item }), item.name || item.id);
+    const mods = executeAlwaysActive(ast, { self: actor, item });
+    const toMerge = (item.type === "weapon" || item.type === "outfit")
+      ? zeroCombatDiceMods(mods)
+      : mods;
+    mergeAlwaysActiveMods(merged, toMerge, item.name || item.id);
   }
 
   return merged;
+}
+
+/**
+ * Always Active power / dice max on this weapon or outfit only.
+ * @param {Item} item
+ * @param {Actor} [actor]
+ * @returns {Record<string, number>}
+ */
+export function getItemAlwaysActiveCombatMods(item, actor) {
+  if (!item) return pickCombatDiceMods();
+  const ast = getAST(item);
+  if (!ast?.blocks.some(b => b.trigger === "Always Active")) return pickCombatDiceMods();
+  const self = actor?.system ? actor : (item.actor ?? null);
+  if (!self) return pickCombatDiceMods();
+  return pickCombatDiceMods(executeAlwaysActive(ast, { self, item }));
 }
 
 function mergeAlwaysActiveMods(merged, mods, sourceName) {

--- a/src/module/easy-effects/registry.js
+++ b/src/module/easy-effects/registry.js
@@ -525,7 +525,7 @@ const TRIGGER_HOOKS = [
   },
 
   // ── [On Action] ─────────────────────────────────────────────────────────────
-  // Fires whenever the actor uses an action or reaction with this item.
+  // Fires for Attack, Block, Counter, Evade, and the sheet [Used Action] / [Used Reaction] buttons.
   {
     hook: "pmttrpg.actorAction",
     triggerName: "On Action",
@@ -534,13 +534,15 @@ const TRIGGER_HOOKS = [
       if (!actor) return [];
       return [...getEquippedItems(actor), ...uniqueStatusItems(actor.items)];
     },
-    buildContext: ({ actor, target }) => {
+    buildContext: ({ actor, target, attacker, defender, clash }) => {
       if (!actor) return null;
       return {
-        self:   actor,
-        target: target ?? null,
-        ally:   null,
-        clash:  null,
+        self:      actor,
+        target:    target ?? null,
+        attacker:  attacker ?? null,
+        defender:  defender ?? null,
+        ally:      null,
+        clash:     clash ?? null,
       };
     },
   },
@@ -765,6 +767,7 @@ export async function runItemEasyEffects(item, triggerName, context = {}) {
 }
 
 /**
+ * [On Action] scripts. On a clash, pass `clash`, `attacker`, and `defender`.
  * @param {object} payload
  * @returns {Promise<void>}
  */

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -16,6 +16,7 @@ import {
   promptDeclareSkillDialog,
 } from "./declare-skill.js";
 import { applyDiceMaxFloor, formatDiceFormula } from "../easy-effects/dice-formula.js";
+import { getItemAlwaysActiveCombatMods } from "../easy-effects/registry.js";
 import { promptRangedAmmo } from "../combat/clash-dialog.js";
 import { resolveRangedDamageType } from "../damage-application.js";
 import { normalizeWeaponProperties } from "./weapon-properties.js";
@@ -206,7 +207,10 @@ export class ItemPMTTRPG extends Item {
 
       dicePowerFromAttack = Number(actorData?.system?.attributes?.attackModifier?.value ?? 0);
       const eeMods = actorData?.system?.attributes?.easyEffectsMods;
-      const eeAttackMax = Number(eeMods?.attackMax ?? 0);
+      const local = getItemAlwaysActiveCombatMods(itemData, actorData);
+      data.alwaysActiveCombatMods = local;
+      const eeAttackMax = Number(eeMods?.attackMax ?? 0) + Number(local.attackMax ?? 0);
+      dicePowerFromAttack += Number(local.attackPower ?? 0);
       const { sides: dieSides, powerAdjust: maxFloorPower } = applyDiceMaxFloor(
         baseDieSides,
         diceMaxBonus + eeAttackMax,
@@ -273,10 +277,12 @@ export class ItemPMTTRPG extends Item {
       const tem = Number(actorData?.system?.abilities?.tem?.value ?? 0);
       const ins = Number(actorData?.system?.abilities?.ins?.value ?? 0);
       const eeMods = actorData?.system?.attributes?.easyEffectsMods;
-      const blockFromEffects = Number(eeMods?.blockPower ?? 0);
-      const evadeFromEffects = Number(eeMods?.evadePower ?? 0);
-      const blockMaxFromEffects = Number(eeMods?.blockMax ?? 0);
-      const evadeMaxFromEffects = Number(eeMods?.evadeMax ?? 0);
+      const local = getItemAlwaysActiveCombatMods(itemData, actorData);
+      data.alwaysActiveCombatMods = local;
+      const blockFromEffects = Number(eeMods?.blockPower ?? 0) + Number(local.blockPower ?? 0);
+      const evadeFromEffects = Number(eeMods?.evadePower ?? 0) + Number(local.evadePower ?? 0);
+      const blockMaxFromEffects = Number(eeMods?.blockMax ?? 0) + Number(local.blockMax ?? 0);
+      const evadeMaxFromEffects = Number(eeMods?.evadeMax ?? 0) + Number(local.evadeMax ?? 0);
 
       const blockMaxApplied = applyDiceMaxFloor(blockBaseSides, blockMaxFromEffects);
       const evadeMaxApplied = applyDiceMaxFloor(evadeBaseSides, evadeMaxFromEffects);

--- a/src/packs/status-pmttrpg-srd/Paralysis_xzOZxRRZvS7pDgl7.yml
+++ b/src/packs/status-pmttrpg-srd/Paralysis_xzOZxRRZvS7pDgl7.yml
@@ -15,7 +15,7 @@ system:
   origin: ''
   customNotes: ''
   easyEffects: |-
-    [On Clash Start]
+    [On Action]
     disadvantage;
     lose 1 Paralysis;
 


### PR DESCRIPTION
## Summary

### New Features

* Clashes now spend the attacker's Action and the defender's Reaction when using Block, Counter, or Evade.
* `[On Action]` now activates before clash dice are rolled, allowing effects like Paralysis and Bleed to trigger at the correct time.
* Recycled Evade and one-sided attacks do not spend a Reaction.
* Added a shared `useActionEconomy()` helper for Action/Reaction usage.

### Bug Fixes

* `[Always Active]` weapon and outfit `power` / `dice max` effects are now scoped to the item they came from instead of stacking across all equipped items.
* `spend N Status to ...` now snapshots the amount being spent before the following actions are run.

## Related issue

Closes #138
Closes #142

## Testing

* [x] Tested locally
* [x] No console errors
